### PR TITLE
resolve target_directory resolve error for cargo-contract v0.8.0+

### DIFF
--- a/packages/redspot-core/src/compiler/ink/resolve.ts
+++ b/packages/redspot-core/src/compiler/ink/resolve.ts
@@ -3,6 +3,7 @@ import { execSync } from 'child_process';
 import fs from 'fs-extra';
 import path from 'path';
 import { RedspotConfig, InkConfig } from '../../types';
+import semver from 'semver';
 
 /* eslint-disable camelcase */
 export interface CargoPackage {
@@ -65,7 +66,17 @@ export function getResolvedWorkspace(findDir?: string): CargoMetadata {
       cwd
     }).toString();
 
-    return JSON.parse(output);
+    const output_obj = JSON.parse(output);
+    const versionData = execSync('cargo contract -V');
+    const version = versionData.toString().split(' ')[1];
+
+    if (semver.gte(version, '0.8.0')) {
+      if (!output_obj.target_directory.endsWith('contracts/target/ink')) {
+        output_obj.target_directory += '/ink';
+      }
+    }
+
+    return output_obj;
   } catch (error) {
     throw new Error(chalk.red(`$ \`${execCommand}\` has failed`));
   }


### PR DESCRIPTION
as mentioned in https://github.com/patractlabs/redspot/issues/65 

I made some minor changes to `redspot-core/compiler/ink/resolver.ts`

The project has no unit test provided. The best I can do is to run a manual test locally on my environment and the issue is resolved at least on my environment. 

It's seems quite odd that according to https://github.com/paritytech/cargo-contract/pull/122 workspace metadata generated by `cargo metadata --no-deps --format-version 1` should've updated the `target_directory` field, but it's just not working as expected on my environment and I really do not wanna dig into the `cargo-contract` code extensively. I am not sure if this is a common problem or it's something with my environment. 


