### PR TITLE
Option to build optimised release contract

### DIFF
--- a/packages/redspot-core/src/builtin-tasks/compile-ink.ts
+++ b/packages/redspot-core/src/builtin-tasks/compile-ink.ts
@@ -59,7 +59,7 @@ subtask(
   async ({ input }: { input: InkInput }, { redspotArguments }) => {
     if (!input.sources.length) return;
 
-    const output = await compile(input, redspotArguments.verbose);
+    const output = await compile(input, redspotArguments.verbose, redspotArguments.release);
 
     return output;
   }

--- a/packages/redspot-core/src/compiler/ink/compile.ts
+++ b/packages/redspot-core/src/compiler/ink/compile.ts
@@ -12,7 +12,7 @@ export type InkOutput = {
   contract: string;
 };
 
-export async function compile(input: InkInput, verbose?: boolean) {
+export async function compile(input: InkInput, verbose?: boolean, release? :boolean) {
   const output: InkOutput[] = [];
 
   for (const source of input.sources) {
@@ -23,6 +23,10 @@ export async function compile(input: InkInput, verbose?: boolean) {
       '--manifest-path',
       source.manifestPath
     ];
+
+    if (release) {
+      args = args.concat('--release');
+    }
 
     if (verbose) {
       args = args.concat('--', 'verbose');

--- a/packages/redspot-core/src/internal/core/params/redspot-params.ts
+++ b/packages/redspot-core/src/internal/core/params/redspot-params.ts
@@ -57,6 +57,15 @@ export const REDSPOT_PARAM_DEFINITIONS: RedspotParamDefinitions = {
     isOptional: true,
     isVariadic: false
   },
+  release: {
+    name: 'release',
+    defaultValue: false,
+    description: 'Enables optimised wasm binary',
+    type: types.boolean,
+    isFlag: true,
+    isOptional: true,
+    isVariadic: false
+  },
   logLevel: {
     name: 'logLevel',
     defaultValue: '2',

--- a/packages/redspot-core/src/types/runtime.ts
+++ b/packages/redspot-core/src/types/runtime.ts
@@ -176,6 +176,7 @@ export interface RedspotArguments {
   logLevel: string;
   maxMemory?: number;
   tsconfig?: string;
+  release: boolean;
 }
 
 export type RedspotParamDefinitions = {


### PR DESCRIPTION
Contracts that are too large will run into the `CodeTooLarge` error.

>  ERROR  contracts.CodeTooLarge                                                            10:27:24
> 
> RedspotPluginError: Instantiation failed
>     at .../node_modules/@redspot/patract/contractFactory.js:209:23

This modification allows contracts to be built with the `--release` option, resulting in smaller `wasm` binaries.


