### PR TITLE
fix compile error by casting project name to string

### DIFF
--- a/packages/redspot-new/src/createApp.ts
+++ b/packages/redspot-new/src/createApp.ts
@@ -42,9 +42,9 @@ function init() {
       '$0 erc20',
       'Initializes a new Substrate contract project in the specified directory'
     )
-    .epilog('Power by patract labs').argv;
+    .epilog('Powered by patract labs').argv;
 
-  const projectName = argv._[0];
+  const projectName = argv._[0].toString();
 
   createApp(projectName, argv.verbose);
 }


### PR DESCRIPTION
I was not able to compile redspot until I applied this fix. It was giving the error below:

`packages/redspot-new/src/createApp.ts(49,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.`
