### PR TITLE
Further 7.2.1 upgrade and expose signer objects

### DIFF
--- a/examples/delegator/package.json
+++ b/examples/delegator/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "resolutions": {
-    "@polkadot/api": "^6.12.1",
-    "@polkadot/api-contract": "^6.12.1",
+    "@polkadot/api": "^7.2.1",
+    "@polkadot/api-contract": "^7.2.1",
     "typescript": "^4.5.4"
   },
   "dependencies": {

--- a/examples/erc20/package.json
+++ b/examples/erc20/package.json
@@ -6,9 +6,9 @@
     "node": ">=14.x"
   },
   "resolutions": {
-    "@polkadot/api": "6.12.1",
-    "@polkadot/api-contract": "6.12.1",
-    "@polkadot/types": "6.12.1",
+    "@polkadot/api": "7.2.1",
+    "@polkadot/api-contract": "7.2.1",
+    "@polkadot/types": "7.2.1",
     "@polkadot/keyring": "8.2.2",
     "@polkadot/util": "8.2.2",
     "@polkadot/wasm-crypto": "4.5.1",

--- a/examples/multi-contract/package.json
+++ b/examples/multi-contract/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "resolutions": {
-    "@polkadot/api": "6.12.1",
-    "@polkadot/api-contract": "6.12.1",
+    "@polkadot/api": "7.2.1",
+    "@polkadot/api-contract": "7.2.1",
     "typescript": "^4.5.4"
   },
   "dependencies": {

--- a/examples/plasm/package.json
+++ b/examples/plasm/package.json
@@ -6,9 +6,9 @@
     "node": ">=14.x"
   },
   "resolutions": {
-    "@polkadot/api": "6.12.1",
-    "@polkadot/api-contract": "6.12.1",
-    "@polkadot/types": "6.12.1",
+    "@polkadot/api": "7.2.1",
+    "@polkadot/api-contract": "7.2.1",
+    "@polkadot/types": "7.2.1",
     "@polkadot/util": "^8.2.2",
     "typescript": "^4.5.4"
   },

--- a/examples/solang/package.json
+++ b/examples/solang/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "resolutions": {
-    "@polkadot/api": "^6.12.1",
-    "@polkadot/api-contract": "^6.12.1",
+    "@polkadot/api": "^7.2.1",
+    "@polkadot/api-contract": "^7.2.1",
     "typescript": "^4.5.4"
   },
   "dependencies": {

--- a/packages/redspot-chai/package.json
+++ b/packages/redspot-chai/package.json
@@ -8,7 +8,7 @@
     "redspot": "^0.13.2-1"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
-    "@polkadot/api-contract": "^6.12.1"
+    "@polkadot/api": "^7.2.1",
+    "@polkadot/api-contract": "^7.2.1"
   }
 }

--- a/packages/redspot-core/package.json
+++ b/packages/redspot-core/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.2.0"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
+    "@polkadot/api": "^7.2.1",
     "abort-controller": "^3.0.0",
     "bn.js": "^5.1.3",
     "chalk": "^4.1.0",

--- a/packages/redspot-core/src/provider/index.ts
+++ b/packages/redspot-core/src/provider/index.ts
@@ -1,1 +1,3 @@
-export { createProvider, createApi, createNetwork } from './construction';
+export { createProvider, createApi, createNetwork, createSigner } from './construction';
+export { Signer as AccountSigner } from './account-signer';
+export { Signer } from './signer'

--- a/packages/redspot-decimals/package.json
+++ b/packages/redspot-decimals/package.json
@@ -8,7 +8,7 @@
     "redspot": "^0.13.2-1"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
-    "@polkadot/api-contract": "^6.12.1"
+    "@polkadot/api": "^7.2.1",
+    "@polkadot/api-contract": "^7.2.1"
   }
 }

--- a/packages/redspot-known-types/package.json
+++ b/packages/redspot-known-types/package.json
@@ -8,7 +8,7 @@
     "redspot": "^0.13.2-1"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
+    "@polkadot/api": "^7.2.1",
     "@polkadot/apps-config": "^0.95.1"
   }
 }

--- a/packages/redspot-patract/package.json
+++ b/packages/redspot-patract/package.json
@@ -8,7 +8,7 @@
     "redspot": "^0.13.2-1"
   },
   "dependencies": {
-    "@polkadot/api": "^6.12.1",
-    "@polkadot/api-contract": "^6.12.1"
+    "@polkadot/api": "^7.2.1",
+    "@polkadot/api-contract": "^7.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,8 +2645,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redspot/chai@workspace:packages/redspot-chai"
   dependencies:
-    "@polkadot/api": ^6.12.1
-    "@polkadot/api-contract": ^6.12.1
+    "@polkadot/api": ^7.2.1
+    "@polkadot/api-contract": ^7.2.1
   peerDependencies:
     redspot: ^0.13.2-1
   languageName: unknown
@@ -2656,8 +2656,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redspot/decimals@workspace:packages/redspot-decimals"
   dependencies:
-    "@polkadot/api": ^6.12.1
-    "@polkadot/api-contract": ^6.12.1
+    "@polkadot/api": ^7.2.1
+    "@polkadot/api-contract": ^7.2.1
   peerDependencies:
     redspot: ^0.13.2-1
   languageName: unknown
@@ -2700,7 +2700,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redspot/known-types@workspace:packages/redspot-known-types"
   dependencies:
-    "@polkadot/api": ^6.12.1
+    "@polkadot/api": ^7.2.1
     "@polkadot/apps-config": ^0.95.1
   peerDependencies:
     redspot: ^0.13.2-1
@@ -2711,8 +2711,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redspot/patract@workspace:packages/redspot-patract"
   dependencies:
-    "@polkadot/api": ^6.12.1
-    "@polkadot/api-contract": ^6.12.1
+    "@polkadot/api": ^7.2.1
+    "@polkadot/api-contract": ^7.2.1
   peerDependencies:
     redspot: ^0.13.2-1
   languageName: unknown
@@ -12501,7 +12501,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "redspot@workspace:packages/redspot-core"
   dependencies:
-    "@polkadot/api": ^6.12.1
+    "@polkadot/api": ^7.2.1
     "@types/mocha": ^5.2.6
     abort-controller: ^3.0.0
     bn.js: ^5.1.3


### PR DESCRIPTION
Hi guys, this upgrades the version of polkadotjs in packages and examples to avoid the yarn warnings. Sorry, I forgot to add this in the last PR.

It also exposes the signer objects, as I found them to be quite useful in development.