### PR TITLE
Allow contract to be queried at a specific block

### DIFF
--- a/packages/redspot-patract/src/contract.ts
+++ b/packages/redspot-patract/src/contract.ts
@@ -161,7 +161,8 @@ function decodeEvents(
 function buildCall(
   contract: Contract,
   fragment: AbiMessage,
-  isEstimateGas = false
+  isEstimateGas = false,
+  at?: string | Uint8Array
 ): ContractFunction<ContractCallOutcome> {
   return async function (
     ...args: TransactionParams
@@ -213,7 +214,9 @@ function buildCall(
           origin
         };
 
-    const json = await contract.api.rpc.contracts.call(rpcParams);
+    const _contractCallFn = contract.api.rpc.contracts.call;
+
+    const json = await (at ? _contractCallFn(rpcParams, at) : _contractCallFn(rpcParams));
 
     const {
       debugMessage,
@@ -451,6 +454,17 @@ export default class Contract {
         this.estimateGas[messageName] = buildEstimate(this, fragment);
       }
     }
+  }
+
+  /**
+   * Query at specific block
+   * 
+   * @param at string | Uint8Array
+   * @param abi AbiMessage
+   * @returns ContractFunction\<ContractCallOutcome\>
+   */
+  public queryAt(at: string | Uint8Array, abi: AbiMessage): ContractFunction<ContractCallOutcome> {
+    return buildCall(this, abi, false, at);
   }
 
   /**


### PR DESCRIPTION
This allows the contract history to be queried via redspot.

`atBlock` can be specified as an optional parameter to a `contractQuery` function as follows.

```
        const query = !atBlock ? signedContract.query[contractMethodName] : signedContract.queryAt(atBlock, signedContract.abi.findMessage(contractMethodName))
        const response = await query(...encodedArgs)
```

This is a code extract from [here](https://github.com/prosopo-io/provider/blob/a00ecb485f4fb6ad1c4882b5df0dcc715120a3b0/src/contract/interface.ts#L97-L109).

* add queryAt

* rename _call to _contractCallFn